### PR TITLE
Add option for query by object_id

### DIFF
--- a/src/bacnet_server/models/model_point.py
+++ b/src/bacnet_server/models/model_point.py
@@ -43,6 +43,11 @@ class BACnetPointModel(db.Model):
         return cls.query.filter_by(uuid=uuid)
 
     @classmethod
+    def find_by_object_id(cls, object_type, address):
+        return cls.query.filter(
+            (BACnetPointModel.object_type == object_type) & (BACnetPointModel.address == address)).first()
+
+    @classmethod
     def delete_all_from_db(cls):
         cls.query.delete()
         db.session.commit()

--- a/src/bacnet_server/resources/point/point_object.py
+++ b/src/bacnet_server/resources/point/point_object.py
@@ -1,0 +1,14 @@
+from flask_restful import marshal_with, abort
+
+from src.bacnet_server.models.model_point import BACnetPointModel
+from src.bacnet_server.resources.mod_fields import point_fields
+from src.bacnet_server.resources.point.point_base import BACnetPointBase
+
+
+class BACnetPointObject(BACnetPointBase):
+    @marshal_with(point_fields)
+    def get(self, object_type, address):
+        point = BACnetPointModel.find_by_object_id(object_type, address)
+        if not point:
+            abort(404, message='BACnet Point is not found')
+        return point

--- a/src/bacnet_server/resources/point/point_object.py
+++ b/src/bacnet_server/resources/point/point_object.py
@@ -1,14 +1,52 @@
-from flask_restful import marshal_with, abort
+import copy
 
+from flask_restful import marshal_with, abort, reqparse
+
+from src.bacnet_server.bac_server import BACServer
 from src.bacnet_server.models.model_point import BACnetPointModel
+from src.bacnet_server.models.model_priority_array import PriorityArrayModel
 from src.bacnet_server.resources.mod_fields import point_fields
 from src.bacnet_server.resources.point.point_base import BACnetPointBase
 
 
 class BACnetPointObject(BACnetPointBase):
+    parser_patch = reqparse.RequestParser()
+    parser_patch.add_argument('object_name', type=str, required=False)
+    parser_patch.add_argument('relinquish_default', type=float, required=False)
+    parser_patch.add_argument("priority_array_write", type=dict, required=False)
+    parser_patch.add_argument('event_state', type=str, required=False)
+    parser_patch.add_argument('units', type=str, required=False)
+    parser_patch.add_argument('description', type=str, required=False)
+    parser_patch.add_argument('enable', type=bool, required=False)
+    parser_patch.add_argument('fault', type=bool, required=False)
+    parser_patch.add_argument('data_round', type=int, required=False)
+    parser_patch.add_argument('data_offset', type=float, required=False)
+
     @marshal_with(point_fields)
     def get(self, object_type, address):
         point = BACnetPointModel.find_by_object_id(object_type, address)
         if not point:
             abort(404, message='BACnet Point is not found')
         return point
+
+    @marshal_with(point_fields)
+    def patch(self, object_type, address):
+        data = BACnetPointObject.parser_patch.parse_args()
+        point = copy.deepcopy(BACnetPointModel.find_by_object_id(object_type, address))
+        if point is None:
+            abort(404, message=f"Does not exist {object_type - address}")
+        try:
+            priority_array_write = data.pop('priority_array_write')
+            non_none_data = {}
+            for key in data.keys():
+                if data[key] is not None:
+                    non_none_data[key] = data[key]
+            if priority_array_write:
+                PriorityArrayModel.filter_by_point_uuid(point.uuid).update(priority_array_write)
+            BACnetPointModel.filter_by_uuid(point.uuid).update(non_none_data)
+            BACServer.get_instance().remove_point(point)
+            point_return = BACnetPointModel.find_by_uuid(point.uuid)
+            BACServer.get_instance().add_point(point_return)
+            return point_return
+        except Exception as e:
+            abort(500, message=str(e))

--- a/src/routes.py
+++ b/src/routes.py
@@ -1,6 +1,7 @@
 from flask_restful import Api
 
 from src import app
+from src.bacnet_server.resources.point.point_object import BACnetPointObject
 from src.bacnet_server.resources.point.point_plural import BACnetPointPlural
 from src.bacnet_server.resources.point.point_singular import BACnetPointSingular
 from src.bacnet_server.resources.server.server import BACnetServer
@@ -14,4 +15,5 @@ api.add_resource(BACnetServer, f'/{api_prefix}/bacnet/server')
 api.add_resource(BACnetServerStatus, f'/{api_prefix}/bacnet/server/status')
 api.add_resource(BACnetPointPlural, f'/{api_prefix}/bacnet/points')
 api.add_resource(BACnetPointSingular, f'/{api_prefix}/bacnet/points/<string:uuid>')
+api.add_resource(BACnetPointObject, f'/{api_prefix}/bacnet/points/<string:object_type>/<string:address>')
 api.add_resource(Ping, f'/{api_prefix}/ping')


### PR DESCRIPTION
### Summary

Added an option for `GET/PATCH` point from `object_id` (`object_id` is the combination of `object_type` and `address`).

**Examples:**

- `GET`: `http://{{bac_rest_ip}}:{{bac_rest_port}}/api/bacnet/points/<object_type>/<address>`
- `PATCH`: `http://{{bac_rest_ip}}:{{bac_rest_port}}/api/bacnet/points/<object_type>/<address>`

**Find postman link:**

https://www.getpostman.com/collections/89824c068c774e5e19bb