### PR TITLE
Improvement/misc

### DIFF
--- a/src/bacnet_server/models/model_point_store.py
+++ b/src/bacnet_server/models/model_point_store.py
@@ -7,7 +7,7 @@ class BACnetPointStoreModel(db.Model):
     __tablename__ = 'bac_points_store'
     point_uuid = db.Column(db.String, db.ForeignKey('bac_points.uuid'), primary_key=True, nullable=False)
     present_value = db.Column(db.Float(), nullable=False)
-    ts = db.Column(db.DateTime, server_default=db.func.now())
+    ts = db.Column(db.DateTime, server_default=db.func.now(), onupdate=db.func.now())
 
     def __repr__(self):
         return f"PointStore(point_uuid = {self.point_uuid})"

--- a/src/bacnet_server/resources/mod_fields.py
+++ b/src/bacnet_server/resources/mod_fields.py
@@ -28,13 +28,13 @@ priority_array_write_fields = OrderedDict({
 
 point_fields = {
     'uuid': fields.String,
-    'object_type': fields.String,
+    'object_type': fields.String(attribute="object_type.name"),
     'object_name': fields.String,
     'address': fields.Integer,
     'relinquish_default': fields.Float,
     'priority_array_write': fields.Nested(priority_array_write_fields),
-    'event_state': fields.String,
-    'units': fields.String,
+    'event_state': fields.String(attribute="event_state.name"),
+    'units': fields.String(attribute="units.name"),
     'description': fields.String,
     'enable': fields.Boolean,
     'fault': fields.Boolean,


### PR DESCRIPTION
### Summary:

- Update `ts` on `point_store` updates (it used to have the created date instead of updated date)
- Return `Enum.name` attribute instead `Enum` (**For an example:** previously we used to have value like `Units.volts` on `unit` field even when we post value `volts` on `unit` field, now it will return `volts` only) 